### PR TITLE
Suppress error message on nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
 install:
   - "pip install -r requirements.txt --allow-all-external --use-mirrors"
 # command to run tests
-script: nosetests
+script: DJANGO_SETTINGS_MODULE="gettingstarted.settings" nosetests
 


### PR DESCRIPTION
Suppres error message on nosetests such as:

```
E
======================================================================
ERROR: Failure: ImproperlyConfigured (Requested setting CACHES, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/nose/loader.py", line 414, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/katoken/work/FikaNote/hello/tests.py", line 1, in <module>
    from django.test import TestCase
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/django/test/__init__.py", line 5, in <module>
    from django.test.client import Client, RequestFactory
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/django/test/client.py", line 11, in <module>
    from django.contrib.auth import authenticate, login, logout, get_user_model
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/django/contrib/auth/__init__.py", line 6, in <module>
    from django.middleware.csrf import rotate_token
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/django/middleware/csrf.py", line 14, in <module>
    from django.utils.cache import patch_vary_headers
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/django/utils/cache.py", line 26, in <module>
    from django.core.cache import get_cache
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/django/core/cache/__init__.py", line 69, in <module>
    if DEFAULT_CACHE_ALIAS not in settings.CACHES:
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/django/conf/__init__.py", line 54, in __getattr__
    self._setup(name)
  File "/home/katoken/work/FikaNote/venv/lib/python2.7/site-packages/django/conf/__init__.py", line 47, in _setup
    % (desc, ENVIRONMENT_VARIABLE))
ImproperlyConfigured: Requested setting CACHES, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```
