### PR TITLE
#33 display confirm dialog before delete agenda.

### DIFF
--- a/app/templates/agenda.html
+++ b/app/templates/agenda.html
@@ -3,6 +3,9 @@
 <script type="text/javascript" src="/static/js/csrf_token_ajax.js"></script>
 <script>
 function deleteAgenda() {
+    if (!window.confirm("Agendaを削除しますか？")) {
+        return;
+    }
     //use original 'this'
     $.ajax({
         type: 'DELETE',
@@ -28,7 +31,7 @@ $(document).ready(function() {
         $.post(url, data, 'json')
          .done(function(response) {
              $('#agenda_list').prepend('<li><a href="' + response.url + '" target="_blank" class="livepreview"> ' + response.title + '</a><i class="delete-agenda icon-trash-empty" id="' + response.id + '"><span>delete</span></i></li>');
-             $('.delete-agenda').click(deleteAgenda);
+             $('#' + response.id).click(deleteAgenda);
              $('#id_url').val('');
          })
          .fail(function(response) {


### PR DESCRIPTION
#33 の確認ダイアログの表示を追加。

URL追加時のイベントハンドラの登録がclassのままだと、既存のURLの削除がURLを新たに追加した分だけ確認ダイアログが出てしまうので、idに変更した。
