### PR TITLE
modify agenda form in shownote forms. change to textarea.

### DIFF
--- a/app/shownoteform.py
+++ b/app/shownoteform.py
@@ -2,5 +2,5 @@ from django import forms
 
 class ShownoteForm(forms.Form):
     title = forms.CharField()
-    agenda = forms.CharField()
+    agenda = forms.CharField(widget=forms.Textarea)
     person = forms.CharField()


### PR DESCRIPTION
shownoteを追加するときのagendaのフォームが
長文を書くときに文章を確認しづらいので、Textareaにした。
