### PR TITLE
fix shrinking footer size in agenda.

### DIFF
--- a/app/templates/agenda.html
+++ b/app/templates/agenda.html
@@ -98,5 +98,6 @@ $(document).ready(function() {
   </div>
 
 </div>
+</div>
 
 {% include "footer.html" %}


### PR DESCRIPTION
期待動作は以下だが、

<img width="500" alt="expect" src="https://cloud.githubusercontent.com/assets/459739/13655704/c1af1d9a-e6a4-11e5-9f55-05776e3b7adf.png">

agendaのページだけ以下のようにcontentブロックに含まれていたので、修正

<img width="500" alt="fail" src="https://cloud.githubusercontent.com/assets/459739/13655713/d94c001c-e6a4-11e5-93bd-d3ec3dad3fa4.png">
