### PR TITLE
herokuがデフォルトで使用するmoduleのインストール

### DIFF
--- a/fikanote/settings.py
+++ b/fikanote/settings.py
@@ -85,7 +85,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # Parse database configuration from $DATABASE_URL
 # Parse database configuration from $DATABASE_URL
-#DATABASES['default'] = dj_database_url.config()
+DATABASES['default'] = dj_database_url.config()
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/fikanote/settings.py
+++ b/fikanote/settings.py
@@ -84,7 +84,8 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # Parse database configuration from $DATABASE_URL
-DATABASES['default'] = dj_database_url.config()
+# Parse database configuration from $DATABASE_URL
+#DATABASES['default'] = dj_database_url.config()
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ mongoengine==0.21.0
 openapi-spec-validator==0.2.9
 pep8==1.7.1
 pipdeptree==1.0.0
+psycopg2-binary==2.8.6
 pymongo==3.11.2
 PyPDF2==1.26.0
 pyrsistent==0.17.3


### PR DESCRIPTION
herokuが利用するのでインストーする必要あり
psycopg2-binaryをrequirementsに追加。